### PR TITLE
fix base64 imgs too long for 255 len migration requirement

### DIFF
--- a/backend/db/migrations/20240413001230-create-image.js
+++ b/backend/db/migrations/20240413001230-create-image.js
@@ -28,7 +28,7 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       url: {
-        type: Sequelize.STRING(255)
+        type: Sequelize.STRING
       },
       createdAt: {
         allowNull: false,


### PR DESCRIPTION
fix base64 imgs too long for 255 len migration requirement